### PR TITLE
revert change in repetition_penalty and reward manger

### DIFF
--- a/verl/experimental/agent_loop/agent_loop.py
+++ b/verl/experimental/agent_loop/agent_loop.py
@@ -376,7 +376,7 @@ class AgentLoopWorker:
         sampling_params = dict(
             temperature=config.temperature,
             top_p=config.top_p,
-            repetition_penalty=1.3,
+            repetition_penalty=1.0,
             logprobs=config.calculate_log_probs,
         )
 


### PR DESCRIPTION
I accidentally pushed an experimental change in repetition_penalty. It should be reverted.
Also reverted change in reward manger, which results grad norm to be nan